### PR TITLE
商品一覧１

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-   # @items = Item.order("created_at DESC")
+    @items = Item.order("created_at DESC")
   end
 
   def new
@@ -21,7 +21,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :text, :category_id, :type_id, :delivery_pay_id, :area_id, :day_id,
-                                 :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :text, :category_id, :type_id, :delivery_pay_id, :area_id, :day_id,:price).merge(user_id: current_user.id)
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,33 +126,37 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>      
+  <% @items.each do |items| %>
+    <li class='list'>
+      <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag items.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <%#if order.item_id.present? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <%# end %>
           <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
+
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= items.name%>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= "配送料負担" %></span>
+            <span><%= items.price%>円<br><%= items.delivery_pay_id%></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
+      <% end %>
+    </li>
+  <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,11 +127,12 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>      
-  <% @items.each do |items| %>
+
+   <% @items.each do |item| %>
     <li class='list'>
       <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag items.image, class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <%#if order.item_id.present? %>
@@ -144,10 +145,10 @@
 
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= items.name%>
+            <%= item.name%>
           </h3>
           <div class='item-price'>
-            <span><%= items.price%>円<br><%= items.delivery_pay_id%></span>
+            <span><%= item.price%>円<br><%= item.delivery_pay_id%></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -156,11 +157,13 @@
         </div>
       <% end %>
     </li>
-  <% end %>
+   <% end %>
+
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+   <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,6 +181,7 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,6 @@
 <%= render "shared/header" %>
 <div class='main'>
 
-  <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
   <div class='title-contents'>
     <h2 class='service-title'>
       人生を変えるフリマアプリ
@@ -17,9 +16,7 @@
       <%= link_to image_tag("dl-android.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面上部の「人生を変えるフリマアプリ」帯部分  %>
 
-  <%# FURIMAが選ばれる3つの理由部分 %>
   <div class='select-reason-contents'>
     <h2 class='title'>
       FURIMAが選ばれる3つの理由
@@ -60,9 +57,7 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAが選ばれる3つの理由部分 %>
 
-  <%# 画面中央の「会員数日本一位」帯部分 %>
   <div class='ad-contents'>
     <h2 class='ad-title'>
       会員数日本一位
@@ -81,9 +76,7 @@
       <%= link_to image_tag("dl-android.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面中央の「会員数日本一位」帯部分 %>
 
-  <%# FURIMAの特徴 %>
   <div class='feature-contents'>
     <h2 class='title'>
       FURIMAの特徴
@@ -118,15 +111,11 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>      
 
    <% @items.each do |item| %>
     <li class='list'>
@@ -148,7 +137,7 @@
             <%= item.name%>
           </h3>
           <div class='item-price'>
-            <span><%= item.price%>円<br><%= item.delivery_pay_id%></span>
+            <span><%= item.price%>円<br><%= item.delivery_pay.name%></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -159,10 +148,6 @@
     </li>
    <% end %>
 
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
    <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -182,11 +167,10 @@
         <% end %>
       </li>
     <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+
     </ul>
   </div>
-  <%# /商品一覧 %>
+
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
  root to: "items#index"
- resources :items, only: [:new, :create] do
+ resources :items, only: [:new, :create, :index] do
  end
 
 


### PR DESCRIPTION
# What
商品一覧機能の実装

# Why
出品した商品をトップページに表示するため

出品した商品の一覧表示ができていること
上から、出品された日時が新しい順に表示されること
「画像/価格/商品名」の3つの情報について表示できていること
売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること

https://gyazo.com/7a933fa12137eaa1c45df94642c0d530

ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/602cc9a84d7e8531a4cba5ebe1ec517e